### PR TITLE
Adds HOC around GraphWrapper

### DIFF
--- a/src/components/GraphWrapper/graphWrapper.test.tsx
+++ b/src/components/GraphWrapper/graphWrapper.test.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import axios from "axios";
 import { waitFor } from "@testing-library/react";
 import GraphWrapper from "./";
@@ -41,23 +41,6 @@ describe("tests for the Graph Component", () => {
       .mockReturnValue(100);
   });
 
-  test("renders initially with info box", async () => {
-    mockedAxios.get.mockRejectedValue(new Error("Async error"));
-
-    const { getByTestId } = render(<GraphWrapper />);
-    const graphInfo = await waitFor(() => getByTestId("graph-info"));
-
-    expect(graphInfo).toBeTruthy();
-    expect(mockedAxios.get).toHaveBeenCalledWith(
-      queryEntities(
-        "",
-        defaultStartTimestamp,
-        defaultEndTimestamp,
-        defaultStepValue
-      )
-    );
-  });
-
   test("shows error dialog if route is selected and error is thrown", async () => {
     mockedAxios.get.mockRejectedValue(new Error("Async error"));
 
@@ -70,28 +53,6 @@ describe("tests for the Graph Component", () => {
     const graphError = await waitFor(() => getByTestId("graph-error"));
 
     expect(graphError).toBeTruthy();
-    expect(mockedAxios.get).toHaveBeenCalledWith(
-      queryEntities(
-        mockSelectedRoutePath,
-        defaultStartTimestamp,
-        defaultEndTimestamp,
-        defaultStepValue
-      )
-    );
-  });
-
-  test("shows warning dialog if the data for query is empty", async () => {
-    mockedAxios.get.mockResolvedValue({ data: { data: { data: [] } } });
-
-    const { getByTestId } = render(
-      <>
-        <TestComponent />
-        <GraphWrapper />
-      </>
-    );
-    const graphWarn = await waitFor(() => getByTestId("graph-warn"));
-
-    expect(graphWarn).toBeTruthy();
     expect(mockedAxios.get).toHaveBeenCalledWith(
       queryEntities(
         mockSelectedRoutePath,

--- a/src/components/GraphWrapper/index.tsx
+++ b/src/components/GraphWrapper/index.tsx
@@ -26,6 +26,7 @@ const GraphWrapper: React.FC = () => {
       selectedStepValue,
     },
   } = TimeQuerierStore.useContainer();
+
   const { data, error, status } = useFetch<apiResponse<queryResponse>>(
     queryEntities(
       selectedRoutePath,
@@ -34,39 +35,6 @@ const GraphWrapper: React.FC = () => {
       selectedStepValue
     )
   );
-  const graphData = data ? data.data : null;
-
-  if (status === "fetching" || status === "init")
-    return (
-      <VStack w="95%" h="100%" margin="auto" justifyContent="center">
-        <CircularProgress size="10vh" isIndeterminate />
-      </VStack>
-    );
-
-  if (error && selectedRoutePath === "") {
-    return (
-      <VStack w="95%" h="100%" margin="auto" justifyContent="center">
-        <Alert
-          status="info"
-          data-testid="graph-info"
-          variant="subtle"
-          flexDirection="column"
-          alignItems="center"
-          justifyContent="center"
-          textAlign="center"
-          height="50%"
-        >
-          <AlertIcon boxSize="40px" mr={0} />
-          <AlertTitle mt={4} mb={1} fontSize="lg">
-            No Entity Selected
-          </AlertTitle>
-          <AlertDescription maxWidth="sm">
-            Kindly select some entity to see its graph.
-          </AlertDescription>
-        </Alert>
-      </VStack>
-    );
-  }
 
   if (error) {
     return (
@@ -86,39 +54,48 @@ const GraphWrapper: React.FC = () => {
             {error}
           </AlertTitle>
           <AlertDescription maxWidth="sm">
-            Some unexpected error occurred while processing the graph.
+            An unexpected error occurred while processing the graph.
           </AlertDescription>
         </Alert>
       </VStack>
     );
   }
 
+  if (status === "fetching" || status === "init")
+    return (
+      <VStack w="95%" h="100%" margin="auto" justifyContent="center">
+        <CircularProgress size="10vh" isIndeterminate />
+      </VStack>
+    );
+
+  if (!data) {
+    return (
+      <Alert
+        status="warning"
+        data-testid="graph-warn"
+        variant="subtle"
+        flexDirection="column"
+        alignItems="center"
+        justifyContent="center"
+        textAlign="center"
+        height="50%"
+      >
+        <AlertIcon boxSize="40px" mr={0} />
+        <AlertTitle mt={4} mb={1} fontSize="lg">
+          No data found
+        </AlertTitle>
+        <AlertDescription maxWidth="sm">
+          There no data for the following entity/time range.
+        </AlertDescription>
+      </Alert>
+    );
+  }
+
   return (
     <VStack w="95%" h="100%" margin="auto" justifyContent="center">
-      {graphData && graphData.data ? (
-        <Box data-testid="graph" width="100%" height="90vh">
-          <ReusableGraph graphData={graphData} />
-        </Box>
-      ) : (
-        <Alert
-          status="warning"
-          data-testid="graph-warn"
-          variant="subtle"
-          flexDirection="column"
-          alignItems="center"
-          justifyContent="center"
-          textAlign="center"
-          height="50%"
-        >
-          <AlertIcon boxSize="40px" mr={0} />
-          <AlertTitle mt={4} mb={1} fontSize="lg">
-            No data found
-          </AlertTitle>
-          <AlertDescription maxWidth="sm">
-            There no data for the following entity/time range.
-          </AlertDescription>
-        </Alert>
-      )}
+      <Box data-testid="graph" width="100%" height="90vh">
+        <ReusableGraph graphData={data.data} />
+      </Box>
     </VStack>
   );
 };

--- a/src/components/RouteVisualiser/index.tsx
+++ b/src/components/RouteVisualiser/index.tsx
@@ -1,0 +1,50 @@
+import React from "react";
+import {
+  Alert,
+  AlertDescription,
+  AlertIcon,
+  AlertTitle,
+  VStack,
+} from "@chakra-ui/react";
+import { GlobalStore } from "../../store/global";
+import GraphWrapper from "../GraphWrapper";
+
+const RouteVisualiser: React.FC = () => {
+  const {
+    globalState: { selectedRoutePath },
+  } = GlobalStore.useContainer();
+
+  // returns an alert when no route is selected
+  if (selectedRoutePath === "") {
+    return (
+      <VStack w="95%" h="100%" margin="auto" justifyContent="center">
+        <Alert
+          status="info"
+          data-testid="graph-info"
+          variant="subtle"
+          flexDirection="column"
+          alignItems="center"
+          justifyContent="center"
+          textAlign="center"
+          height="50%"
+        >
+          <AlertIcon boxSize="40px" mr={0} />
+          <AlertTitle mt={4} mb={1} fontSize="lg">
+            No Entity Selected
+          </AlertTitle>
+          <AlertDescription maxWidth="sm">
+            Kindly select some entity to see its graph.
+          </AlertDescription>
+        </Alert>
+      </VStack>
+    );
+  }
+
+  return (
+    <div data-testid="graphwrapper">
+      <GraphWrapper />
+    </div>
+  );
+};
+
+export default RouteVisualiser;

--- a/src/components/RouteVisualiser/routeVisualiser.test.tsx
+++ b/src/components/RouteVisualiser/routeVisualiser.test.tsx
@@ -1,0 +1,52 @@
+import React from "react";
+import { waitFor } from "@testing-library/react";
+import SelectedRoute from ".";
+import {
+  mockSelectedRouteName,
+  mockSelectedRoutePath,
+} from "../../mock/mockGraph";
+import { GlobalStore } from "../../store/global";
+import { render } from "../../utils/customRender";
+
+const TestComponent = () => {
+  const store = GlobalStore.useContainer();
+  React.useEffect(() => {
+    store.changeRoute(mockSelectedRouteName, mockSelectedRoutePath);
+  }, []);
+  return null;
+};
+
+describe("tests the SelectedRoute component", () => {
+  beforeEach(() => {
+    jest
+      .spyOn(HTMLElement.prototype, "clientHeight", "get")
+      .mockReturnValue(100);
+    jest
+      .spyOn(HTMLElement.prototype, "clientWidth", "get")
+      .mockReturnValue(100);
+  });
+
+  test("renders the alert info when there is no selected route", async () => {
+    const { getByTestId } = render(
+      <>
+        <SelectedRoute />
+      </>
+    );
+    const graphInfo = await waitFor(() => getByTestId("graph-info"));
+
+    expect(graphInfo).toBeTruthy();
+  });
+
+  test("renders the GraphWrapper when there exists a selected route", async () => {
+    const { getByTestId } = render(
+      <>
+        <TestComponent />
+        <SelectedRoute />
+      </>
+    );
+
+    const graphInfo = await waitFor(() => getByTestId("graphwrapper"));
+
+    expect(graphInfo).toBeTruthy();
+  });
+});

--- a/src/layouts/BasicLayout.tsx
+++ b/src/layouts/BasicLayout.tsx
@@ -1,5 +1,5 @@
 // default imports.
-import React, { Fragment } from "react";
+import React from "react";
 import { GlobalStore } from "../store/global";
 import { TimeQuerierStore } from "../store/timeQuerier";
 
@@ -9,11 +9,9 @@ interface PageProps {
 
 const BasicLayout: React.FC<PageProps> = (props: PageProps) => {
   return (
-    <Fragment>
-      <GlobalStore.Provider>
-        <TimeQuerierStore.Provider>{props.children}</TimeQuerierStore.Provider>
-      </GlobalStore.Provider>
-    </Fragment>
+    <GlobalStore.Provider>
+      <TimeQuerierStore.Provider>{props.children}</TimeQuerierStore.Provider>
+    </GlobalStore.Provider>
   );
 };
 

--- a/src/pages/Home/index.tsx
+++ b/src/pages/Home/index.tsx
@@ -1,17 +1,18 @@
 import React from "react";
 import { Grid, GridItem, useColorModeValue } from "@chakra-ui/react";
 import Sidebar from "../../components/Sidebar";
-import GraphWrapper from "../../components/GraphWrapper";
+import RouteVisualiser from "../../components/RouteVisualiser";
 
 const Home: React.FC = () => {
   const value = useColorModeValue("lightSecondary", "darkSecondary");
+
   return (
     <Grid h="100vh" templateColumns="repeat(24, 1fr)">
       <GridItem bg={value} colSpan={5}>
         <Sidebar />
       </GridItem>
       <GridItem colSpan={19}>
-        <GraphWrapper />
+        <RouteVisualiser />
       </GridItem>
     </Grid>
   );


### PR DESCRIPTION
The graph wrapper on a first render will always make a query to `/query-entity` route.

The fix was to add a higher order component around graphwrapper to render it conditionally based on the values of selectedRoute.

Fixes #36