### PR TITLE
Fix prettier endofline error

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -47,5 +47,11 @@ module.exports = {
     "import/prefer-default-export": "off",
     "@typescript-eslint/explicit-function-return-type": "off",
     "@typescript-eslint/no-var-requires": "off",
+    "prettier/prettier": [
+      "warn",
+      {
+        endOfLine: "auto",
+      },
+    ],
   },
 };


### PR DESCRIPTION
eslint throwing error when we make changes in file. Its because of prettier end of line check issue. To read more (https://github.com/prettier/eslint-plugin-prettier/issues/211). 
Error :
![Screenshot (19)](https://user-images.githubusercontent.com/52108435/142278461-bbc57d1d-9151-4e5e-b410-4eed20fc6fe3.png)

