### PR TITLE
remove any annotation from catch error block

### DIFF
--- a/src/utils/useFetch.ts
+++ b/src/utils/useFetch.ts
@@ -74,7 +74,7 @@ const useFetch = <T = unknown>(
           if (cancelRequest.current) return;
 
           dispatch({ type: "success", payload: response.data });
-        } catch (error: any) {
+        } catch (error) {
           // Let's keep error handling to another day,
           // hence the type for error is "any" here.
           if (cancelRequest.current) return;


### PR DESCRIPTION
Hi,  In TypeScript, catch clause variables may not have a type annotation (aside from, as of TypeScript 4.0, unknown).It doesn't allow type annotations on catch clauses because there's really no way to know what type an exception will have. You can throw objects of any type and system generated exceptions (such as out of memory exception) can technically happen at any time.

So removed Any annotation from try catch block also its giving the error.

